### PR TITLE
Make a copy of kwargs dict

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,26 +1,31 @@
 # Change Log
 
+## 0.5.1
+
+* Fixed key-value arguments loss when `PatchSpec` instance is called more than
+  once
+
 ## 0.5.0
 
-* new class `LazyInstance`
+* New class `LazyInstance`
 
 ## 0.4.0
 
-* new class `AssertRaises`
+* New class `AssertRaises`
 
 ## 0.3.0
 
 * `make_mock` now passes its arguments to `unittest.mock.Mock`
-* new method `TestCase.assert_not_called`
+* New method `TestCase.assert_not_called`
 
 ## 0.2.0
 
-* added functions
+* Added functions
   * `cover_typing`
   * `make_callable`
   * `make_mock`
   * `make_type`
-* added classes
+* Added classes
   * `PatcherFactory`
 
 ## 0.1.0

--- a/src/vutils/testing/mock.py
+++ b/src/vutils/testing/mock.py
@@ -81,10 +81,11 @@ class PatchSpec:
            *target*, the mock object, and additional arguments given by
            *kwargs*, respectively
         """
-        mock: Union["Mock", object] = self.__kwargs.pop("new", make_mock())
+        kwargs: Dict[str, object] = self.__kwargs.copy()
+        mock: Union["Mock", object] = kwargs.pop("new", make_mock())
         if self.__setupfunc is not None:
             self.__setupfunc(mock)
-        return _make_patch(self.__target, mock, **self.__kwargs)
+        return _make_patch(self.__target, mock, **kwargs)
 
 
 class PatchingContextManager:

--- a/src/vutils/testing/version.py
+++ b/src/vutils/testing/version.py
@@ -8,4 +8,4 @@
 #
 """Holds `vutils.testing` version."""
 
-__version__: str = "0.5.0"
+__version__: str = "0.5.1"

--- a/tests/unit/test_mock.py
+++ b/tests/unit/test_mock.py
@@ -144,6 +144,21 @@ class PatchSpecTestCase(PatchXTestCaseBase):
         self.assert_called_with(setupfunc, new)
         self.assert_called_with(self.patch, self.target, new, create=True)
 
+    def test_patch_spec_for_side_effects(self):
+        """Test `PatchSpec` for side effects."""
+        new = 1
+        patchspec = PatchSpec(self.target, None, new=new)
+
+        with self.patcher.patch():
+            patchspec()
+
+        self.assert_called_with(self.patch, self.target, new)
+
+        with self.patcher.patch():
+            patchspec()
+
+        self.assert_called_with(self.patch, self.target, new)
+
 
 class PatchingContextManagerTestCase(TestCase):
     """Test case for `PatchingContextManager`."""


### PR DESCRIPTION
Prevent key-value arguments loss when `PatchSpec` instance is called more than once.