### PR TITLE
Test cover_typing as last

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,16 +115,24 @@ therefore improve coverage reports:
 if typing.TYPE_CHECKING:
     from foopkg import _A, _B, _C
 
-# In test_foo.py:
-from foopkg.foo import func_a
+# In test_coverage.py:
+import pytest
 
-# Use after imports so module cache is populated with proper modules. When
-# called, following happens:
-# - typing.TYPE_CHECKING is patched to True
-# - foopkg is patched with _A, _B, and _C symbols if they do not exist
-# - finally, foopkg.foo is reloaded
-cover_typing("foopkg.foo", ["_A", "_B", "_C"])
+from vutils.testing.utils import cover_typing
+
+# Ensure the test run as last (this feature is available after installing
+# pytest-order). cover_typing reloads the module which may have negative
+# consequences on other tests
+@pytest.mark.order("last")
+def test_typing_code_is_covered():
+    # When called, following happens:
+    # - typing.TYPE_CHECKING is patched to True
+    # - foopkg is patched with _A, _B, and _C symbols if they do not exist
+    # - finally, foopkg.foo is reloaded
+    cover_typing("foopkg.foo", ["_A", "_B", "_C"])
 ```
+The story behind `cover_typing` is to keep source files clean from directives
+telling the `pytest` and linters what to do.
 
 ### Deferred Instance Initialization
 

--- a/src/vutils/testing/utils.py
+++ b/src/vutils/testing/utils.py
@@ -370,7 +370,18 @@ def cover_typing(name: str, symbols: Iterable[str]) -> None:
 
         cover_typing("foo.bar", ["_TypeA", "_TypeB"])
 
-    in the test code after imports.
+    Since this function uses `importlib.reload`, unpleasant side-effects may
+    occur. To avoid this, put your `cover_typing` code into separate file and
+    tell to ``pytest`` to run it as last (use ``pytest-order`` plugin) ::
+
+        import pytest
+
+        from vutils.testing.utils import cover_typing
+
+
+        @pytest.mark.order("last")
+        def test_typing_code_is_covered():
+            cover_typing("foo.bar", ["_TypeA", "_TypeB"])
     """
     module = importlib.import_module(name)
     patcher = TypingPatcher()

--- a/tests/unit/test_coverage.py
+++ b/tests/unit/test_coverage.py
@@ -1,0 +1,30 @@
+#                                                         -*- coding: utf-8 -*-
+# File:    ./tests/unit/test_coverage.py
+# Author:  Jiří Kučera <sanczes AT gmail.com>
+# Date:    2022-06-03 21:49:58 +0200
+# Project: vutils-testing: Auxiliary library for writing tests
+#
+# SPDX-License-Identifier: MIT
+#
+"""Coverage tests."""
+
+import pytest
+
+from vutils.testing.utils import cover_typing
+
+from .common import SYMBOLS
+
+
+@pytest.mark.order("last")
+def test_typing_code_is_covered():
+    """
+    Ensure typing code coverage.
+
+    This is a dummy test that executes `cover_typing` to ensure that the code
+    under ``if TYPE_CHECKING:`` branch is covered. Since `cover_typing` reloads
+    the module, run this test as last to prevent mangling of yet imported
+    modules.
+    """
+    cover_typing("vutils.testing.mock", SYMBOLS)
+    cover_typing("vutils.testing.testcase", SYMBOLS)
+    cover_typing("vutils.testing.utils", SYMBOLS)

--- a/tests/unit/test_mock.py
+++ b/tests/unit/test_mock.py
@@ -18,11 +18,7 @@ from vutils.testing.mock import (
     make_mock,
 )
 from vutils.testing.testcase import TestCase
-from vutils.testing.utils import cover_typing, make_type
-
-from .common import SYMBOLS
-
-cover_typing("vutils.testing.mock", SYMBOLS)
+from vutils.testing.utils import make_type
 
 
 class MakeMockTestCase(TestCase):

--- a/tests/unit/test_testcase.py
+++ b/tests/unit/test_testcase.py
@@ -10,11 +10,6 @@
 
 from vutils.testing.mock import make_mock
 from vutils.testing.testcase import TestCase
-from vutils.testing.utils import cover_typing
-
-from .common import SYMBOLS
-
-cover_typing("vutils.testing.testcase", SYMBOLS)
 
 
 class TestCaseTestCase(TestCase):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -12,24 +12,16 @@ import sys
 
 from vutils.testing.mock import make_mock
 from vutils.testing.testcase import TestCase
-from vutils.testing.utils import (
-    AssertRaises,
-    LazyInstance,
-    cover_typing,
-    make_type,
-)
+from vutils.testing.utils import AssertRaises, LazyInstance, make_type
 
 from .common import (
     FOO_CONSTANT,
-    SYMBOLS,
     FooError,
     StderrPatcher,
     StderrWriter,
     func_a,
     func_b,
 )
-
-cover_typing("vutils.testing.utils", SYMBOLS)
 
 
 class MakeTypeTestCase(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -22,10 +22,11 @@ deps =
     safety
     pytest
     pytest-cov
+    pytest-order
     coveralls
 commands =
     safety check --full-report
-    pytest --cov=vutils.testing --cov-report=term-missing tests
+    pytest -v --cov=vutils.testing --cov-report=term-missing tests
     {env:COVERALLS_CMD:coveralls --output={envname}-coverage.txt}
 
 [linters]
@@ -89,6 +90,7 @@ description =
     {envname}: Run static code checks
 deps =
     pylint
+    pytest
 commands =
     pylint setup.py src/vutils/testing tests/unit
 


### PR DESCRIPTION
Move `cover_typing` to sole test and run it as last. This is due the module reloading in `cover_typing` can cause unpleasant side-effects in tests.