### PR TITLE
Metadata cleanup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ classifiers =
     Topic :: Software Development :: Testing :: Unit
     Topic :: Utilities
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 description = Auxiliary library for writing tests
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./setup.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-06-21 23:58:43 +0200

--- a/src/vutils/testing/__init__.py
+++ b/src/vutils/testing/__init__.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/testing/__init__.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-06-21 23:58:43 +0200

--- a/src/vutils/testing/__init__.pyi
+++ b/src/vutils/testing/__init__.pyi
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/testing/__init__.pyi
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-09-17 14:14:50 +0200

--- a/src/vutils/testing/mock.py
+++ b/src/vutils/testing/mock.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/testing/mock.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-09-13 17:04:14 +0200

--- a/src/vutils/testing/testcase.py
+++ b/src/vutils/testing/testcase.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/testing/testcase.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-09-02 00:59:53 +0200

--- a/src/vutils/testing/utils.py
+++ b/src/vutils/testing/utils.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/testing/utils.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-09-14 17:12:48 +0200

--- a/src/vutils/testing/version.py
+++ b/src/vutils/testing/version.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/testing/version.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-06-21 23:58:43 +0200

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/__init__.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-06-21 23:58:43 +0200

--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/common.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-09-22 23:46:47 +0200

--- a/tests/unit/test_coverage.py
+++ b/tests/unit/test_coverage.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/test_coverage.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2022-06-03 21:49:58 +0200

--- a/tests/unit/test_mock.py
+++ b/tests/unit/test_mock.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/test_mock.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-09-16 22:48:07 +0200

--- a/tests/unit/test_testcase.py
+++ b/tests/unit/test_testcase.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/test_testcase.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-09-11 08:30:17 +0200

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/test_utils.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-09-16 21:22:45 +0200

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/test_version.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2021-06-21 23:58:43 +0200


### PR DESCRIPTION
Metadata cleanup
- remove `coding` marks (not needed in Python 3 anymore)
- use `license_files` (`license_file` is obsolete)