### PR TITLE
Add new class ClassLikeSymbol

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.6.0
+
+* New class `ClassLikeSymbol`
+
 ## 0.5.3
 
 * Fix PEP 585 issue

--- a/README.md
+++ b/README.md
@@ -134,6 +134,30 @@ def test_typing_code_is_covered():
 The story behind `cover_typing` is to keep source files clean from directives
 telling the `pytest` and linters what to do.
 
+Sometimes a symbol can play two roles. Suppose that symbol `_L` is a type alias
+for `list[object]` when `mypy` is performing its checks and `list` otherwise:
+```python
+# In foopkg/foo.py module:
+if typing.TYPE_CHECKING:
+    from foopkg import _L
+else:
+    _L = list
+
+
+class ListType(_L):
+    pass
+```
+To cover this case, `ClassLikeSymbol` from `vutils.testing.utils` comes to
+help. In `test_coverage.py`, just define `_L` like
+```python
+class _L(metaclass=ClassLikeSymbol):
+    pass
+```
+and then pass it to `cover_typing`:
+```python
+cover_typing("foopkg.foo", [_L])
+```
+
 ### Deferred Instance Initialization
 
 Patching may take no effect if the patched object appears in constructor and

--- a/src/vutils/testing/utils.py
+++ b/src/vutils/testing/utils.py
@@ -354,6 +354,20 @@ class TypingPatcher(PatcherFactory):
             self.add_spec(f"{target}.{symbol}", new=symbol, create=True)
 
 
+class ClassLikeSymbol(type):
+    """Meta class for class-like symbols."""
+
+    __slots__ = ()
+
+    def __repr__(cls) -> str:
+        """
+        Return the class-like symbol name.
+
+        :return: the class-like symbol name
+        """
+        return cls.__name__
+
+
 def cover_typing(name: str, symbols: Iterable[str]) -> None:
     """
     Cover the ``if typing.TYPE_CHECKING`` branch.

--- a/src/vutils/testing/version.py
+++ b/src/vutils/testing/version.py
@@ -8,4 +8,4 @@
 #
 """Holds `vutils.testing` version."""
 
-__version__: str = "0.5.3"
+__version__: str = "0.6.0"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -12,7 +12,12 @@ import sys
 
 from vutils.testing.mock import make_mock
 from vutils.testing.testcase import TestCase
-from vutils.testing.utils import AssertRaises, LazyInstance, make_type
+from vutils.testing.utils import (
+    AssertRaises,
+    ClassLikeSymbol,
+    LazyInstance,
+    make_type,
+)
 
 from .common import (
     FOO_CONSTANT,
@@ -131,3 +136,17 @@ class AssertRaisesTestCase(TestCase):
         self.run_and_verify(wfunc_b)
         self.assertEqual(wfunc_b.get_exception().detail, FOO_CONSTANT)
         self.assertIsNone(wfunc_b.get_exception())
+
+
+class ClassLikeSymbolTestCase(TestCase):
+    """Test case for `ClassLikeSymbol`."""
+
+    __slots__ = ()
+
+    def test_repr_returns_class_name(self):
+        """Test whether `repr` returns a class name."""
+
+        class DummySymbol(metaclass=ClassLikeSymbol):
+            """Dummy symbol."""
+
+        self.assertEqual(f"{DummySymbol}", DummySymbol.__name__)


### PR DESCRIPTION
Helps with testing symbols which are used as base classes. Reason: Python <3.9 does not understand
```python
class X(list[object]): pass
```
and `mypy` does not accept
```python
class X(list): pass
```
Therefore
```python
if typing.TYPE_CHECKING:
    from mymodule import L  # defined in __init__.pyi
else:
    L = list

class X(L): pass
```
is needed. To make `cover_typing` succeed on this code snipped, `L` must be a class with `repr(L) == "L"`, which is what `ClassLikeSymbol` is good for:
```python
class L(metaclass=ClassLikeSymbol): pass

cover_typing("mymodule.mysubmodule", [L])
```