### PR TITLE
Do not build universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,9 +63,6 @@ test =
 [options.packages.find]
 where = src
 
-[bdist_wheel]
-universal = True
-
 [sdist]
 formats = zip, gztar
 


### PR DESCRIPTION
Universal wheels (Python 2 + 3 compatible wheels) will be deprecated in the near future.